### PR TITLE
Upgraded Asyn to build in S3DF

### DIFF
--- a/configure/CONFIG_SITE
+++ b/configure/CONFIG_SITE
@@ -79,7 +79,7 @@ GRAPHICSMAGICK_EXTERNAL = YES
 
 AREA_DETECTOR	= $(TOP)
 # Get settings from AREA_DETECTOR, so we only have to configure once for all detectors if we want to
--include $(AREA_DETECTOR)/configure/CONFIG_SITE
+#-include $(AREA_DETECTOR)/configure/CONFIG_SITE
 -include $(AREA_DETECTOR)/configure/CONFIG_SITE.$(EPICS_HOST_ARCH)
 -include $(AREA_DETECTOR)/configure/CONFIG_SITE.$(EPICS_HOST_ARCH).Common
 ifdef T_A

--- a/configure/RELEASE.local
+++ b/configure/RELEASE.local
@@ -20,7 +20,7 @@
 # could match a directory name.
 # ==========================================================
 ADSUPPORT_MODULE_VERSION        = R1.9-0.1.0
-ASYN_MODULE_VERSION             = R4.39-1.0.1
+ASYN_MODULE_VERSION             = R4.39-1.0.2
 
 # ==========================================================
 # Define module paths using pattern


### PR DESCRIPTION
Upgrading Asyn in configure/RELEASE.local.

This line was commented out in CONFIG_SITE:
`-include $(AREA_DETECTOR)/configure/CONFIG_SITE`

It was causing the error `configure/CONFIG_SITE:82: *** Too many open files.  Stop.`

After commenting out, the build succeeded. I don't know if it will cause trouble for other modules or if this would affect only modules loaded as sub-modules in Area Detector. Let's keep an eye.